### PR TITLE
Fix for using read-only scope on Strava API

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -61,4 +61,18 @@ class Provider extends AbstractProvider implements ProviderInterface
             'grant_type' => 'authorization_code',
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state)
+    {
+        $codeFields = parent::getCodeFields($state);
+
+        if(count($this->scopes) === 0) {
+            unset($codeFields['scope']);
+        }
+
+        return $codeFields;
+    }
 }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SocialiteProviders\Strava;
 
 use Laravel\Socialite\Two\AbstractProvider;
@@ -69,7 +70,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     {
         $codeFields = parent::getCodeFields($state);
 
-        if(count($this->scopes) === 0) {
+        if (count($this->scopes) === 0) {
             unset($codeFields['scope']);
         }
 

--- a/src/StravaExtendSocialite.php
+++ b/src/StravaExtendSocialite.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SocialiteProviders\Strava;
 
 use SocialiteProviders\Manager\SocialiteWasCalled;


### PR DESCRIPTION
I have overridden the `getCodeFields` method so it removes the scope field when there are not scopes provided. This fixes issue #1.  
