### PR TITLE
set email to null

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -53,7 +53,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'    => $user['id'], 'nickname' => null,
             'name'  => $user['firstname'].' '.$user['lastname'],
-            'email' => $user['email'], 'avatar' => $user['profile_medium'],
+            'email' => null, 'avatar' => $user['profile_medium'],
         ]);
     }
 


### PR DESCRIPTION
since January 15, 2019, Email address is no longer part of the profile:read_all scope and is removed from the athlete model.

Source: https://developers.strava.com/docs/oauth-updates/